### PR TITLE
Add bundled TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="cypress" />
+
+declare function onProxy(on: Cypress.PluginEvents): Cypress.PluginEvents
+export = onProxy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "cypress-on-fix",
       "version": "0.0.0-development",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
       "devDependencies": {
         "cypress": "^13.8.1",
-        "debug": "^4.3.4",
         "prettier": "^3.2.5",
         "semantic-release": "^21.0.1"
       }
@@ -1753,12 +1755,11 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3740,10 +3741,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -10050,12 +10050,11 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -11497,10 +11496,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "neo-async": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,17 @@
     "url": "https://github.com/bahmutov/cypress-on-fix/issues"
   },
   "homepage": "https://github.com/bahmutov/cypress-on-fix#readme",
+  "dependencies": {
+    "debug": "^4.3.7"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "devDependencies": {
     "cypress": "^13.8.1",
-    "debug": "^4.3.4",
     "prettier": "^3.2.5",
     "semantic-release": "^21.0.1"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Hallo, thanks for the package! Incredibly helpful for this limitation in Cypress. 

I've created a PR here to bundle some types to add TypeScript support for users installing this directly from NPM. This helps when using a `cypress.config.ts` and getting those helpful type checks for free:

![image](https://github.com/user-attachments/assets/2c79bd67-0a86-42e7-822a-a1098f6dadec)
